### PR TITLE
Update tests from latest mod.rs on libc-0.2 branch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,4 +11,4 @@ build-std = ["std", "panic_abort"]
 
 [env]
 MCU="esp32c6"
-ESP_IDF_VERSION = "v5.3.2"
+ESP_IDF_VERSION = "v5.5.3"

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           token: ${{ secrets.WOKWI_CLI_TOKEN }}
           timeout: 10000
-          fail_text: 'Mismatch detected for'
-          expect_text: 'Returned from app_main()'
+          fail_text: 'mismatch(es) detected!'
+          expect_text: 'All checks passed!'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ debug     = true
 opt-level = "z"
 
 [dependencies]
-esp-idf-svc = { version = "0.51.0", default-features = false, features = [
+esp-idf-svc = { version = "0.52.1", default-features = false, features = [
     "alloc",
     "binstart",
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ esp-idf-svc = { version = "0.52.1", default-features = false, features = [
     "binstart",
     "std",
 ] }
-libc = "0.2.170"
+libc = "0.2"
 log = { version = "0.4.26", default-features = false }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,15 +72,27 @@ fn main() {
     esp_idf_svc::sys::link_patches();
     esp_idf_svc::log::EspLogger::initialize_default();
 
-    // newlib/espidf module (https://github.com/rust-lang/libc/blob/main/src/unix/newlib/espidf/mod.rs)
+    // Most of these tests can be generated with:
+    // sed -n 's/.*pub type \(.*\) = .*/    check_types!(\1);/p' mod.rs | uniq
+    // sed -n 's/.*pub struct \(.*\) {.*/    check_types!(\1);/p' mod.rs | uniq
+    // sed -n 's/.*pub const \(.*\):.*/    check_constants!(\1);/p' mod.rs | uniq
+    // You should manually check for `cfg` expressions in the source, though.
+    // Then you should then manually remove any items that don't have a binding in `esp_idf_svc::sys`.
+    // And finally you should remove duplicates.
+
+    // newlib/espidf module (https://github.com/rust-lang/libc/blob/libc-0.2/src/unix/newlib/espidf/mod.rs)
     check_types!(clock_t);
+    check_types!(wchar_t);
     check_types!(cmsghdr);
     check_types!(msghdr);
+    //check_types!(sockaddr_un); // No binding
     check_types!(sockaddr);
     check_types!(sockaddr_in6);
     check_types!(sockaddr_in);
     check_types!(sockaddr_storage);
+    //check_constants!(AF_UNIX); // No binding
     check_constants!(AF_INET6);
+    //check_constants!(FIONBIO); // No binding
     check_constants!(POLLIN);
     check_constants!(POLLRDNORM);
     check_constants!(POLLRDBAND);
@@ -111,8 +123,9 @@ fn main() {
     check_constants!(SIGHUP);
     check_constants!(SIGQUIT);
     check_constants!(NSIG);
+    check_constants!(SOMAXCONN);
 
-    // newlib module (https://github.com/rust-lang/libc/blob/main/src/unix/newlib/mod.rs)
+    // newlib module (https://github.com/rust-lang/libc/blob/libc-0.2/src/unix/newlib/mod.rs)
     check_types!(blkcnt_t);
     check_types!(blksize_t);
     check_types!(clockid_t);
@@ -135,6 +148,7 @@ fn main() {
     check_types!(nlink_t);
     check_types!(pthread_t);
     check_types!(pthread_key_t);
+    //check_types!(rlim_t); // No binding
     check_types!(sa_family_t);
     check_types!(socklen_t);
     check_types!(speed_t);
@@ -142,18 +156,27 @@ fn main() {
     check_types!(tcflag_t);
     check_types!(useconds_t);
     check_types!(time_t);
-    check_types!(hostent);
+    // structs
     check_types!(addrinfo);
     check_types!(ip_mreq);
-    check_types!(linger);
     check_types!(in_addr);
-    check_types!(pollfd);
+    //check_types!(lconv); // No binding
     check_types!(tm);
     check_types!(sigaction);
     check_types!(stack_t);
     check_types!(fd_set);
+    //check_types!(passwd); // No binding
     check_types!(termios);
+    //check_types!(sem_t); // No binding
+    //check_types!(utsname); // No binding
+    //check_types!(cpu_set_t); // No binding
     check_types!(pthread_attr_t);
+    check_types!(pthread_rwlockattr_t);
+    check_types!(pthread_mutex_t);
+    check_types!(pthread_rwlock_t);
+    check_types!(pthread_mutexattr_t);
+    check_types!(pthread_cond_t);
+    check_types!(pthread_condattr_t);
     check_constants!(NCCS);
     check_constants!(PTHREAD_MUTEX_NORMAL);
     check_constants!(PTHREAD_MUTEX_RECURSIVE);
@@ -268,13 +291,14 @@ fn main() {
     check_constants!(O_EXCL);
     check_constants!(O_SYNC);
     check_constants!(O_NONBLOCK);
+    //check_constants!(O_ACCMODE); // No binding
     check_constants!(O_CLOEXEC);
-    check_constants!(STDIN_FILENO);
-    check_constants!(STDOUT_FILENO);
-    check_constants!(STDERR_FILENO);
+    //check_constants!(RTLD_LAZY); // No binding
     check_constants!(SEEK_SET);
     check_constants!(SEEK_CUR);
     check_constants!(SEEK_END);
+    //check_constants!(FIOCLEX); // No binding
+    //check_constants!(FIONCLEX); // No binding
     check_constants!(S_BLKSIZE);
     check_constants!(S_IREAD);
     check_constants!(S_IWRITE);
@@ -297,16 +321,36 @@ fn main() {
     check_constants!(S_IROTH);
     check_constants!(S_IWOTH);
     check_constants!(S_IXOTH);
+    //check_constants!(SOL_TCP); // No binding
     check_constants!(PF_UNSPEC);
     check_constants!(PF_INET);
     check_constants!(PF_INET6);
     check_constants!(AF_UNSPEC);
     check_constants!(AF_INET);
+    //check_constants!(CLOCK_REALTIME); // No binding
+    //check_constants!(CLOCK_MONOTONIC); // No binding
+    //check_constants!(CLOCK_BOOTTIME); // No binding
     check_constants!(SOCK_STREAM);
     check_constants!(SOCK_DGRAM);
     check_constants!(SHUT_RD);
     check_constants!(SHUT_WR);
     check_constants!(SHUT_RDWR);
+    /* No bindings
+    check_constants!(SO_BINTIME);
+    check_constants!(SO_NO_OFFLOAD);
+    check_constants!(SO_NO_DDP);
+    check_constants!(SO_REUSEPORT_LB);
+    check_constants!(SO_LABEL);
+    check_constants!(SO_PEERLABEL);
+    check_constants!(SO_LISTENQLIMIT);
+    check_constants!(SO_LISTENQLEN);
+    check_constants!(SO_LISTENINCQLEN);
+    check_constants!(SO_SETFIB);
+    check_constants!(SO_USER_COOKIE);
+    check_constants!(SO_PROTOCOL);
+    check_constants!(SO_PROTOTYPE);
+    check_constants!(SO_VENDOR);
+    */
     check_constants!(SO_DEBUG);
     check_constants!(SO_ACCEPTCONN);
     check_constants!(SO_REUSEADDR);
@@ -317,6 +361,9 @@ fn main() {
     check_constants!(SO_LINGER);
     check_constants!(SO_OOBINLINE);
     check_constants!(SO_REUSEPORT);
+    //check_constants!(SO_TIMESTAMP); // No binding
+    //check_constants!(SO_NOSIGPIPE); // No binding
+    //check_constants!(SO_ACCEPTFILTER); // No binding
     check_constants!(SO_SNDBUF);
     check_constants!(SO_RCVBUF);
     check_constants!(SO_SNDLOWAT);
@@ -327,7 +374,29 @@ fn main() {
     check_constants!(SO_TYPE);
     check_constants_manually!("SOCK_CLOEXEC", sys::O_CLOEXEC, libc::SOCK_CLOEXEC);
     check_constants!(INET_ADDRSTRLEN);
+    /* No bindings
+    check_constants!(IFF_UP);
+    check_constants!(IFF_BROADCAST);
+    check_constants!(IFF_DEBUG);
+    check_constants!(IFF_LOOPBACK);
+    check_constants!(IFF_POINTOPOINT);
+    check_constants!(IFF_NOTRAILERS);
+    check_constants!(IFF_RUNNING);
+    check_constants!(IFF_NOARP);
+    check_constants!(IFF_PROMISC);
+    check_constants!(IFF_ALLMULTI);
+    check_constants!(IFF_OACTIVE);
+    check_constants!(IFF_SIMPLEX);
+    check_constants!(IFF_LINK0);
+    check_constants!(IFF_LINK1);
+    check_constants!(IFF_LINK2);
+    check_constants!(IFF_ALTPHYS);
+    check_constants!(IFF_MULTICAST);
+    */
     check_constants!(TCP_NODELAY);
+    //check_constants!(TCP_MAXSEG); // No binding
+    //check_constants!(TCP_NOPUSH); // No binding
+    //check_constants!(TCP_NOOPT); // No binding
     check_constants!(TCP_KEEPIDLE);
     check_constants!(TCP_KEEPINTVL);
     check_constants!(TCP_KEEPCNT);
@@ -351,6 +420,7 @@ fn main() {
     check_constants!(NO_DATA);
     check_constants!(NO_RECOVERY);
     check_constants!(TRY_AGAIN);
+    //check_constants!(NO_ADDRESS); // No binding
     check_constants!(AI_PASSIVE);
     check_constants!(AI_CANONNAME);
     check_constants!(AI_NUMERICHOST);
@@ -358,6 +428,9 @@ fn main() {
     check_constants!(AI_ADDRCONFIG);
     check_constants!(NI_MAXHOST);
     check_constants!(NI_MAXSERV);
+    //check_constants!(NI_NOFQDN); // No binding
+    //check_constants!(NI_NUMERICHOST); // No binding
+    //check_constants!(NI_NAMEREQD); // No binding
     check_constants!(NI_NUMERICSERV);
     check_constants!(NI_DGRAM);
     check_constants!(EAI_FAMILY);
@@ -366,4 +439,130 @@ fn main() {
     check_constants!(EAI_SOCKTYPE);
     check_constants!(EXIT_SUCCESS);
     check_constants!(EXIT_FAILURE);
+    //check_constants!(PRIO_PROCESS); // No binding
+    //check_constants!(PRIO_PGRP); // No binding
+    //check_constants!(PRIO_USER); // No binding
+
+    // unix module (https://github.com/rust-lang/libc/blob/libc-0.2/src/unix/mod.rs)
+    check_types!(intmax_t);
+    check_types!(uintmax_t);
+    /* No bindings
+    check_types!(size_t);
+    check_types!(ptrdiff_t);
+    check_types!(intptr_t);
+    check_types!(uintptr_t);
+    check_types!(ssize_t);
+    */
+    check_types!(pid_t);
+    check_types!(in_addr_t);
+    check_types!(in_port_t);
+    //check_types!(sighandler_t); // No binding
+    check_types!(cc_t);
+    check_types!(uid_t);
+    check_types!(gid_t);
+    check_types!(locale_t);
+    // structs
+    //check_types!(group); // No binding
+    check_types!(utimbuf);
+    check_types!(timeval);
+    check_types!(timespec);
+    //check_types!(rlimit); // No binding
+    //check_types!(rusage); // No binding
+    check_types!(ipv6_mreq);
+    check_types!(hostent);
+    check_types!(iovec);
+    check_types!(pollfd);
+    //check_types!(winsize); // No binding
+    check_types!(linger);
+    check_types!(sigval);
+    check_types!(itimerval);
+    check_types!(tms);
+    //check_types!(servent); // No binding
+    //check_types!(protoent); // No binding
+    check_types!(in6_addr);
+    /* No bindings
+    check_constants!(INT_MIN);
+    check_constants!(INT_MAX);
+    check_constants!(SIG_DFL);
+    check_constants!(SIG_IGN);
+    check_constants!(SIG_ERR);
+    */
+    check_constants!(DT_UNKNOWN);
+    //check_constants!(DT_FIFO); // No binding
+    //check_constants!(DT_CHR); // No binding
+    check_constants!(DT_DIR);
+    //check_constants!(DT_BLK); // No binding
+    check_constants!(DT_REG);
+    //check_constants!(DT_LNK); // No binding
+    //check_constants!(DT_SOCK); // No binding
+    check_constants!(FD_CLOEXEC);
+    //check_constants!(USRQUOTA); // No binding
+    //check_constants!(GRPQUOTA); // No binding
+    check_constants!(SIGIOT);
+    check_constants!(S_ISUID);
+    check_constants!(S_ISGID);
+    check_constants!(S_ISVTX);
+    check_constants!(IF_NAMESIZE);
+    check_constants!(IFNAMSIZ);
+    /* No bindings
+    check_constants!(LOG_EMERG);
+    check_constants!(LOG_ALERT);
+    check_constants!(LOG_CRIT);
+    check_constants!(LOG_ERR);
+    check_constants!(LOG_WARNING);
+    check_constants!(LOG_NOTICE);
+    check_constants!(LOG_INFO);
+    check_constants!(LOG_DEBUG);
+    check_constants!(LOG_KERN);
+    check_constants!(LOG_USER);
+    check_constants!(LOG_MAIL);
+    check_constants!(LOG_DAEMON);
+    check_constants!(LOG_AUTH);
+    check_constants!(LOG_SYSLOG);
+    check_constants!(LOG_LPR);
+    check_constants!(LOG_NEWS);
+    check_constants!(LOG_UUCP);
+    check_constants!(LOG_LOCAL0);
+    check_constants!(LOG_LOCAL1);
+    check_constants!(LOG_LOCAL2);
+    check_constants!(LOG_LOCAL3);
+    check_constants!(LOG_LOCAL4);
+    check_constants!(LOG_LOCAL5);
+    check_constants!(LOG_LOCAL6);
+    check_constants!(LOG_LOCAL7);
+    check_constants!(LOG_PID);
+    check_constants!(LOG_CONS);
+    check_constants!(LOG_ODELAY);
+    check_constants!(LOG_NDELAY);
+    check_constants!(LOG_NOWAIT);
+    check_constants!(LOG_PRIMASK);
+    check_constants!(LOG_FACMASK);
+    check_constants!(PRIO_MIN);
+    check_constants!(PRIO_MAX);
+    */
+    check_constants!(IPPROTO_ICMP);
+    check_constants!(IPPROTO_ICMPV6);
+    check_constants!(IPPROTO_TCP);
+    check_constants!(IPPROTO_UDP);
+    check_constants!(IPPROTO_IP);
+    check_constants!(IPPROTO_IPV6);
+    /* No bindings
+    check_constants!(INADDR_LOOPBACK);
+    check_constants!(INADDR_ANY);
+    check_constants!(INADDR_BROADCAST);
+    check_constants!(INADDR_NONE);
+    check_constants!(IN6ADDR_LOOPBACK_INIT);
+    check_constants!(IN6ADDR_ANY_INIT);
+    check_constants!(ARPOP_REQUEST);
+    check_constants!(ARPOP_REPLY);
+    check_constants!(ATF_COM);
+    check_constants!(ATF_PERM);
+    check_constants!(ATF_PUBL);
+    check_constants!(ATF_USETRAILERS);
+    */
+
+    // misc
+    check_constants!(STDIN_FILENO);
+    check_constants!(STDOUT_FILENO);
+    check_constants!(STDERR_FILENO);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,14 @@
+use core::sync::atomic::{AtomicU32, Ordering};
 use esp_idf_svc::sys;
+
+// Only atomics can be global variables -- avoids the need to pass
+// count as parameter to the macro.
+static MISMATCH_COUNT: AtomicU32 = AtomicU32::new(0);
 
 macro_rules! check_constants_manually {
     ($name:expr, $const1:expr, $const2:expr) => {
         if $const1.to_string() != $const2.to_string() {
+            MISMATCH_COUNT.fetch_add(1, Ordering::Relaxed);
             log::error!(
                 "Mismatch detected for constant `{}`: `esp-idf` {} | `libc` {}",
                 $name,
@@ -16,6 +22,7 @@ macro_rules! check_constants_manually {
 macro_rules! check_constants {
     ($ident:ident) => {
         if sys::$ident.to_string() != libc::$ident.to_string() {
+            MISMATCH_COUNT.fetch_add(1, Ordering::Relaxed);
             log::error!(
                 "Mismatch detected for constant `{}`: `esp-idf` {} | `libc` {}",
                 stringify!($ident),
@@ -29,6 +36,7 @@ macro_rules! check_constants {
 macro_rules! check_types_manually {
     ($name:expr, $size1:expr, $size2:expr, $align1:expr, $align2:expr) => {
         if $size1.to_string() != $size2.to_string() {
+            MISMATCH_COUNT.fetch_add(1, Ordering::Relaxed);
             log::error!(
                 "Mismatch detected for type `{}` size: `esp-idf` {} | `libc` {}",
                 $name,
@@ -37,6 +45,7 @@ macro_rules! check_types_manually {
             );
         }
         if $align1.to_string() != $align2.to_string() {
+            MISMATCH_COUNT.fetch_add(1, Ordering::Relaxed);
             log::error!(
                 "Mismatch detected for type `{}` alignment: `esp-idf` {} | `libc` {}",
                 $name,
@@ -50,6 +59,7 @@ macro_rules! check_types_manually {
 macro_rules! check_types {
     ($ident:ident) => {
         if std::mem::size_of::<sys::$ident>() != std::mem::size_of::<libc::$ident>() {
+            MISMATCH_COUNT.fetch_add(1, Ordering::Relaxed);
             log::error!(
                 "Mismatch detected for type `{}` size: `esp-idf` {} | `libc` {}",
                 stringify!($ident),
@@ -58,6 +68,7 @@ macro_rules! check_types {
             );
         }
         if std::mem::align_of::<sys::$ident>() != std::mem::align_of::<libc::$ident>() {
+            MISMATCH_COUNT.fetch_add(1, Ordering::Relaxed);
             log::error!(
                 "Mismatch detected for type `{}` alignment: `esp-idf` {} | `libc` {}",
                 stringify!($ident),
@@ -565,4 +576,11 @@ fn main() {
     check_constants!(STDIN_FILENO);
     check_constants!(STDOUT_FILENO);
     check_constants!(STDERR_FILENO);
+
+    let count = MISMATCH_COUNT.load(Ordering::Relaxed);
+    if count == 0 {
+        log::info!("All checks passed!");
+    } else {
+        log::error!("{} mismatch(es) detected!", count);
+    }
 }


### PR DESCRIPTION
Semi-manually generated with `sed` scripts.

Some context that might be useful, pondering about picolibc support eventually, see https://github.com/esp-rs/esp-idf-sys/pull/408#issuecomment-4140529860 .

Adding those new checks make the test fail, not sure if those are definitions you intentionally ignored, or if these are new failures:
```
I (347) main_task: Calling app_main()
E (347) libc_checks: Mismatch detected for type `pthread_rwlockattr_t` size: `esp-idf` 4 | `libc` 12
E (347) libc_checks: Mismatch detected for type `pthread_rwlockattr_t` alignment: `esp-idf` 4 | `libc` 1
E (357) libc_checks: Mismatch detected for type `pthread_mutex_t` size: `esp-idf` 4 | `libc` 8
E (367) libc_checks: Mismatch detected for type `pthread_mutex_t` alignment: `esp-idf` 4 | `libc` 8
E (377) libc_checks: Mismatch detected for type `pthread_rwlock_t` size: `esp-idf` 4 | `libc` 8
E (377) libc_checks: Mismatch detected for type `pthread_rwlock_t` alignment: `esp-idf` 4 | `libc` 8
E (387) libc_checks: Mismatch detected for type `pthread_cond_t` size: `esp-idf` 4 | `libc` 8
E (397) libc_checks: Mismatch detected for type `pthread_cond_t` alignment: `esp-idf` 4 | `libc` 8
E (417) libc_checks: Mismatch detected for type `tms` size: `esp-idf` 0 | `libc` 16
E (417) libc_checks: Mismatch detected for type `tms` alignment: `esp-idf` 1 | `libc` 4
E (427) libc_checks: Mismatch detected for constant `DT_DIR`: `esp-idf` 2 | `libc` 4
E (427) libc_checks: Mismatch detected for constant `DT_REG`: `esp-idf` 1 | `libc` 8
E (437) libc_checks: Mismatch detected for constant `IF_NAMESIZE`: `esp-idf` 6 | `libc` 16
E (447) libc_checks: Mismatch detected for constant `IFNAMSIZ`: `esp-idf` 6 | `libc` 16
I (457) main_task: Returned from app_main()
```

Also added some code to make sure all of the test runs in wokwi-ci, instead of exiting early.